### PR TITLE
remove yellow call on string

### DIFF
--- a/lib/pronto/erb_lint.rb
+++ b/lib/pronto/erb_lint.rb
@@ -26,7 +26,7 @@ module Pronto
         config = ::ERBLint::RunnerConfig.new(file_loader.yaml(config_filename))
         @config = ::ERBLint::RunnerConfig.default.merge(config)
       else
-        warn "#{config_filename} not found: using default config".yellow
+        warn "#{config_filename} not found: using default config"
         @config = RunnerConfig.default
       end
       @config.merge!(runner_config_override)


### PR DESCRIPTION
`erb_lint` no longer uses colorize for coloring strings—they've switched to Rainbow. Moreover, if the color gem used here is not in this gem's gemspec its API probably shouldn't be used to avoid issues like this during optimistic gem upgrades `('erb_lint', '~> 0.0.24')`.

```
/usr/local/bundle/gems/pronto-erb_lint-0.1.5/lib/pronto/erb_lint.rb:29:in `load_config': undefined method `yellow' for ".erb-lint.yml not found: using default config":String (NoMethodError)
```