### PR TITLE
Fix default config constant

### DIFF
--- a/lib/pronto/erb_lint.rb
+++ b/lib/pronto/erb_lint.rb
@@ -27,7 +27,7 @@ module Pronto
         @config = ::ERBLint::RunnerConfig.default.merge(config)
       else
         warn "#{config_filename} not found: using default config"
-        @config = RunnerConfig.default
+        @config = ::ERBLint::RunnerConfig.default
       end
       @config.merge!(runner_config_override)
     rescue Psych::SyntaxError => e


### PR DESCRIPTION
This may be the result of newer versions of ruby resolving constants differently. With ruby 2.6.5, if a config file is not present in the tree hierarchy, we see this error:

```
	 6: from /ruby_version/lib/ruby/gems/2.6.0/gems/pronto-0.10.0/lib/pronto.rb:64:in `run'
	 5: from /ruby_version/lib/ruby/gems/2.6.0/gems/pronto-0.10.0/lib/pronto/runners.rb:13:in `run'
	 4: from /ruby_version/lib/ruby/gems/2.6.0/gems/pronto-0.10.0/lib/pronto/runners.rb:13:in `each'
	 3: from /ruby_version/lib/ruby/gems/2.6.0/gems/pronto-0.10.0/lib/pronto/runners.rb:20:in `block in run'
	 2: from /ruby_version/lib/ruby/gems/2.6.0/gems/pronto-0.10.0/lib/pronto/runners.rb:20:in `new'
	 1: from /ruby_version/lib/ruby/gems/2.6.0/gems/pronto-erb_lint-0.1.5/lib/pronto/erb_lint.rb:13:in `initialize'
/ruby_version/lib/ruby/gems/2.6.0/gems/pronto-erb_lint-0.1.5/lib/pronto/erb_lint.rb:30:in `load_config': uninitialized constant Pronto::ERBLint::RunnerConfig (NameError)
Did you mean?  Pronto::Runners
```

This change solves that problem.