### PR TITLE
Use the right ERBLint::RunnerConfig class for default config

### DIFF
--- a/lib/pronto/erb_lint.rb
+++ b/lib/pronto/erb_lint.rb
@@ -27,7 +27,7 @@ module Pronto
         @config = ::ERBLint::RunnerConfig.default.merge(config)
       else
         warn "#{config_filename} not found: using default config"
-        @config = RunnerConfig.default
+        @config = ::ERBLint::RunnerConfig.default
       end
       @config.merge!(runner_config_override)
     rescue Psych::SyntaxError => e


### PR DESCRIPTION
I had the following error:

```
/home/ylecuyer/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/pronto-erb_lint-0.1.5/lib/pronto/erb_lint.rb:30:in `load_config': uninitialized constant Pronto::ERBLint::RunnerConfig (NameError)
	Did you mean?  Pronto::Runners
```

In the if branch it has the right class but here it doesn't ¯\_(ツ)_/¯
