### PR TITLE
Update to latest erb, Ruby support changed in v0.0.35

### DIFF
--- a/pronto-erb_lint.gemspec
+++ b/pronto-erb_lint.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.summary = 'Pronto runner for ERB Lint, erb code analyzer'
 
   s.licenses = ['MIT']
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.5.0'
   s.rubygems_version = '1.8.23'
 
   s.files = `git ls-files`.split($RS).reject do |file|
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ['LICENSE', 'README.md']
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency('erb_lint', '~> 0.0.24')
+  s.add_runtime_dependency('erb_lint', '~> 0.1.1')
   s.add_runtime_dependency('pronto', '> 0.9.0')
   s.add_development_dependency('rake', '~> 12.0')
   s.add_development_dependency('rspec', '~> 3.4')


### PR DESCRIPTION
Would resolve #6 

Updates to the latest erb lint. Support for Ruby < 2.5 was dropped in erb lint v0.0.35 

https://github.com/Shopify/erb-lint/releases/tag/v0.0.35